### PR TITLE
Docs: Add libevent-dev to Ubuntu build requirements

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -56,7 +56,7 @@ Build requirements:
 
 	sudo apt-get install build-essential
 	sudo apt-get install libtool autotools-dev autoconf automake
-	sudo apt-get install libssl-dev
+	sudo apt-get install libssl-dev libevent-dev
 
 for Ubuntu 12.04 and later:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -20,6 +20,7 @@ Dependencies
  Library     | Purpose          | Description
  ------------|------------------|----------------------
  libssl      | SSL Support      | Secure communications
+ libevent    | Networking       | OS independent asynchronous networking
  libdb4.8    | Berkeley DB      | Wallet storage
  libboost    | Boost            | C++ Library
  miniupnpc   | UPnP Support     | Optional firewall-jumping support


### PR DESCRIPTION
Build failing on fresh install of Ubuntu 16.04 with error: 

`error: "libevent not found"`

Solution: add `libevent-dev` to build requirements.