### PR TITLE
Add path prefix to strip command

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -9,8 +9,10 @@ To Build
 	./configure
 
 	make
-	
-	strip straksd straks-cli straks-qt
+
+	strip src/straksd src/straks-cli src/qt/straks-qt
+
+	make install # optional
 
 This will build straks-qt as well if the dependencies are met.
 


### PR DESCRIPTION
Binaries are build inside the `src/` folder so `strip straksd straks-cli straks-qt` doesn't work in the root path.

- Added `src` prefix to `strip` command. `src/qt` prefix is required for the `straks-qt` binary
- Added optional `make install` command to install binaries to system path

