### PR TITLE
Update to libqt5core5a

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -110,7 +110,7 @@ To build with Qt 4 you need the following:
 
 For Qt 5 you need the following:
 
-    sudo apt-get install libqt5gui5 libqt5core5 libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev
+    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev
 
 libqrencode (optional) can be installed with:
 


### PR DESCRIPTION
Update required to build in Ubuntu 18.04 as old package is no longer maintained. This is already updated in the automated dependency script.